### PR TITLE
updated build script

### DIFF
--- a/dpkg/build_pkg.sh
+++ b/dpkg/build_pkg.sh
@@ -2,10 +2,14 @@
 
 cd content
 
+mkdir -p usr/lib/kaifareader/
+mkdir -p etc/kaifareader/
+mkdir -p lib/systemd/system/
+
 # copy files to debian package structure
-cp -v ../../kaifareader.py               usr/lib/kaifareader/
-cp -v ../../meter_template.json          etc/kaifareader/
-cp -v ../../systemd/kaifareader.service  lib/systemd/system/
+cp -v ../../kaifareader.py usr/lib/kaifareader/
+cp -v ../../meter.json etc/kaifareader/
+cp -v ../../systemd/kaifareader.service lib/systemd/system/
 
 dpkg-buildpackage -uc -us
 

--- a/dpkg/content/debian/install
+++ b/dpkg/content/debian/install
@@ -1,5 +1,3 @@
-etc/kaifareader/meter_template.json
+etc/kaifareader/meter.json
 lib/systemd/system/kaifareader.service
 usr/lib/kaifareader/kaifareader.py
-
-


### PR DESCRIPTION
updated the build script so that the needed directories are created first (otherwise it fails) and meter.json is used instead of meter_template.json. 