### PR TITLE
Implement MQTT export function

### DIFF
--- a/meter_template.json
+++ b/meter_template.json
@@ -10,5 +10,10 @@
   "interval": 15,
   "supplier": "TINETZ",
   "export_format": "SOLARVIEW",
-  "export_file_abspath": "/var/run/kaifareader/kaifa.txt"
+  "export_file_abspath": "/var/run/kaifareader/kaifa.txt",
+  "export_mqtt_server": "mymqtt.examplebroker.com",
+  "export_mqtt_port": 1883,
+  "export_mqtt_user": "mymqttuser",
+  "export_mqtt_password": "supersecretmqttpass",
+  "export_mqtt_basetopic": "kaifareader"
 }


### PR DESCRIPTION
Implement a new export function for mqtt brokers.
It requires paho-mqtt python module. `pip3 install paho-mqtt`
To activate set the `export_format` key in your config to `MQTT`,
configure the keys `export_mqtt_server`, `export_mqtt_port`,
`export_mqtt_user`,`export_mqtt_password` and `export_mqtt_basetopic`
to reflect your environment.

Stefan, i am not sure this matches your style- and quality standards but i tried to stay as close to your style as i could.
I tested it in my environment and had no problems running it against a mosquitto mqtt server.
Please have a look and let me know if you can merge this. 

Cheers, Tom