### PR TITLE
Drop `readline()` for `read()`; Remove wait for next frame1;

### DIFF
--- a/meter_template.json
+++ b/meter_template.json
@@ -7,7 +7,7 @@
   "stopbits": "serial.STOPBITS_ONE",
   "bytesize": "serial.EIGHTBITS",
   "key_hex_string": "",
-  "interval": 15,
+  "interval": 1,
   "supplier": "TINETZ",
   "export_format": "SOLARVIEW",
   "export_file_abspath": "/var/run/kaifareader/kaifa.txt",


### PR DESCRIPTION
- Instead of using `readline()` we use `read()` to read the
byte-stream in chunks of 100bytes. This requires the interval
to be carefully set. It should not be >= 5.
Tested successfully with intervals from 1s to 4s.
All work, but i do recommend to stick with 1s or 2s interval
(serial read timeout).

- Changed the way we test for a complete segment: We can now tell
when the end of a segment is reached by comparing the *number of
bytes we want to read* to the *number of bytes we actually got*.
This enables us to check if we received a full segment by looking
for the known end_byte to actually sit at end of the segment.



I would be happy if you could test this PR a bit and let me know
your findings and thoughts. 

Thank you very much.